### PR TITLE
Mark License::SPDX as a test dependency

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -15,7 +15,9 @@
     "Archive::Libarchive"
   ],
   "build-depends": [],
-  "test-depends": [],
+  "test-depends": [
+    "License::SPDX:ver<3.21.0+>"
+  ],
   "provides": {
     "Collection": "lib/Collection.rakumod",
     "Collection::Entities": "lib/Collection/Entities.rakumod",


### PR DESCRIPTION
Because it is one:

Error while compiling /mnt/f/raku-doc-website/site#sources/59D2EC3FF8872079799020C04DDFCB0FB60C090E (Collection::TestPlugin) Could not find License::SPDX in:
    /home/pm1540/.rakubrew/versions/moar-2023.04/share/perl6/site
    /home/pm1540/.rakubrew/versions/moar-2023.04/share/perl6/vendor
    /home/pm1540/.rakubrew/versions/moar-2023.04/share/perl6/core
    CompUnit::Repository::AbsolutePath<55807064>
    CompUnit::Repository::NQP<61969280>
    CompUnit::Repository::Perl5<61969320>
at /mnt/f/raku-doc-website/site#sources/59D2EC3FF8872079799020C04DDFCB0FB60C090E (Collection::TestPlugin):4